### PR TITLE
Fixed String Issue - Included cstring lib

### DIFF
--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <stdlib.h>
 #include <android/log.h>
-
+#include <cstring>
 /*
     Copyright (C) 2016  Christos Kyriakopoylos
 


### PR DESCRIPTION
Fixed String Issue In Android Studio - "use of undeclared identifier strcpy" & "use of undeclared identifier strncpy"