### PR TITLE
Improve save/load of .wpc file of Reaver

### DIFF
--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <android/log.h>
-#include <cstring>
 
 /*
     Copyright (C) 2019  Christos Kyriakopoulos

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <android/log.h>
+#include <cstring>
 
 /*
     Copyright (C) 2019  Christos Kyriakopoulos

--- a/app/src/main/java/com/hijacker/ReaverFragment.java
+++ b/app/src/main/java/com/hijacker/ReaverFragment.java
@@ -389,7 +389,7 @@ public class ReaverFragment extends Fragment{
             stop(PROCESS_AIRODUMP);            //Can't have channels changing from anywhere else
             try{
                 BufferedReader out;
-                String args = "-i " + iface + " -vv";
+                String args = "-i " + iface + " -vv -s " + Environment.getExternalStorageDirectory() + "/Hijacker" + ap.mac.replaceAll("[:]","") + ".wpc";
                 args += ap==null ? " -b " + custom_mac : " -b " + ap.mac + " --channel " + ap.ch;
                 args += " -d " + pinDelay;
                 args += " -l " + lockedDelay;


### PR DESCRIPTION
* Improve loading of Reaver session file .wpc with adding the "-s" cmd line and location of storage

Fixes so that Reaver gets the saved sessions instead of starting all over each time the process is interrupted.